### PR TITLE
Display ankh counter

### DIFF
--- a/SetupTrackers.lua
+++ b/SetupTrackers.lua
@@ -197,6 +197,8 @@ function TotemTimers.AnkhEvent(self, event)
     elseif self.timer.timers[1]<=0 and duration>2 then
         self.timer:Start(1,start+duration-floor(GetTime()),1800)
     end
+
+    self.count:SetText("x" .. GetItemCount("Ankh"))
 end
 
 --local shieldtable = {SpellNames[SpellIDs.LightningShield], SpellNames[SpellIDs.WaterShield], SpellNames[SpellIDs.EarthShield]}


### PR DESCRIPTION
Sometimes you forget how much ankh reagent you currently have in your bag, so it may be good idea to display it right on the ankh timer icon

looks like this
![image](https://user-images.githubusercontent.com/1529526/82258405-16fce400-995a-11ea-9784-d52fa543728a.png)

I was thinking if display this count in icon or bellow like the shield counter, but this was simpler and does not collide with cooldown timer
